### PR TITLE
Fix constructor error and BDUtils not existing.

### DIFF
--- a/Plugins/DownloadEmotes/DownloadEmotes.plugin.js
+++ b/Plugins/DownloadEmotes/DownloadEmotes.plugin.js
@@ -87,7 +87,7 @@ module.exports = !global.ZeresPluginLibrary
       stop() {}
     }
   : (([Plugin, Library]) => {
-      const { Patcher, WebpackModules, DCM } = Library;
+      const { Patcher, WebpackModules, DCM, PluginUtilities } = Library;
       let downloadsFolder;
       class DownloadEmotes extends Plugin {
         constructor() {
@@ -130,7 +130,7 @@ module.exports = !global.ZeresPluginLibrary
             return (downloadsFolder = downloadPath);
           else {
             downloadsFolder = path.join(
-              BDUtils.getPluginsFolder(),
+              PluginUtilities.getPluginsFolder(),
               "downloads"
             );
             if (!fs.existsSync(downloadsFolder)) fs.mkdirSync(downloadsFolder);
@@ -252,11 +252,11 @@ module.exports = !global.ZeresPluginLibrary
           }
         }
 
-        getDescription() {
+        /*getDescription() {
           return `${
             config.info.description
           }. Emotes are saved here: ${this.getDownloadLocation()}`;
-        }
+        }*/
 
         onStop() {
           Patcher.unpatchAll();

--- a/Plugins/DownloadEmotes/DownloadEmotes.plugin.js
+++ b/Plugins/DownloadEmotes/DownloadEmotes.plugin.js
@@ -252,11 +252,11 @@ module.exports = !global.ZeresPluginLibrary
           }
         }
 
-        /*getDescription() {
+        getDescription() {
           return `${
             config.info.description
           }. Emotes are saved here: ${this.getDownloadLocation()}`;
-        }*/
+        }
 
         onStop() {
           Patcher.unpatchAll();


### PR DESCRIPTION
- Included PluginUtilities from Api and used it in place of BDUtils.