### PR TITLE
Fixed spelling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -21,7 +21,7 @@ body:
   - type: textarea
     id: steps-to-reproduce
     attributes:
-      label: How can i recreate this bug
+      label: How can I recreate this bug
       description: Give me a list of steps in order to recreate the bug.
       placeholder: |
         1. Do ...


### PR DESCRIPTION
Wasn't capitalized ¯\_(ツ)_/¯