### PR TITLE
BetterInvites - Load server banner as gif instead of png where possible

### DIFF
--- a/Plugins/BetterInvites/BetterInvites.plugin.js
+++ b/Plugins/BetterInvites/BetterInvites.plugin.js
@@ -156,8 +156,12 @@ module.exports = !global.ZeresPluginLibrary
                         component.props.children.splice(2, 0,
                             React.createElement("div", { className: `${config.info.name}-guildBanner`, style: { position: "relative", marginBottom: "1%" } },
                                 React.createElement("img", {
-                                    src: `https://cdn.discordapp.com/banners/${guild.id}/${guild.banner}.png?size=1024`,
-                                    style: { width: "100%", height: "auto", maxHeight: "100px", borderRadius: "5px", objectFit: "cover" }
+                                    src: `https://cdn.discordapp.com/banners/${guild.id}/${guild.banner}.gif?size=1024`,
+                                    style: { width: "100%", height: "auto", maxHeight: "100px", borderRadius: "5px", objectFit: "cover" },
+                                    onError: (e) => {
+                                        e.target.onError = null
+                                        e.target.src = `https://cdn.discordapp.com/banners/${guild.id}/${guild.banner}.png?size=1024`
+                                    }
                                 })
                             )
                         )


### PR DESCRIPTION
Looks cool, tested it too :)
![BetterInvitesGif](https://user-images.githubusercontent.com/62797992/153604576-c5e3abe8-f8fe-46e5-8833-24afbb81c146.gif)

See lines 155-168 of `Plugins/BetterInvites/BetterInvites.plugin.js` for the changes I made!