### PR TITLE
Rename lint workflow to eslint and update job name

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -3,7 +3,7 @@ on:
     pull_request
 
 jobs:
-  test:
+  eslint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Renamed the workflow file from lint.yml to eslint.yml and updated the job name from 'test' to 'eslint' for clarity and consistency.